### PR TITLE
fix talent presets, phase sorting, defaults, etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
           </div>
           <div class="u-custom-menu u-nav-container">
             <ul class="u-custom-font u-nav u-text-font u-unstyled u-nav-1"><li class="u-nav-item"><a class="u-button-style u-custom-color-2 u-nav-link u-text-active-custom-color-3 u-text-hover-custom-color-5" href="index.html" style="padding: 10px 20px;">Main</a>
-</li></ul>
+            </li></ul>
           </div>
           <!-- <div class="u-custom-menu u-nav-container-collapse">
             <div class="u-black u-container-style u-inner-container-layout u-opacity u-opacity-95 u-sidenav">
@@ -765,8 +765,7 @@
           <li><label class="label-2">Latency (ms)</label><input type="number" step="1" min="10" max="1000" class="number-input hover-grey fight-setting-input-3" id="latency" onchange=fightSettings() value="50"></li>
           <li><label class="label-2">Player Uptime (%)</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey fight-setting-input-3" id="playeruptime" onchange=fightSettings() value="100"> %</li>
           <li><label class="label-2">Pet Uptime (%)</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey fight-setting-input-3" id="petuptime" onchange=fightSettings() value="100"> %</li>
-          <li><label class="label-2">Weave Time (s)</label><input type="number" step="0.1" min="0" max="2" class="number-input hover-grey fight-setting-input-3" id="weavetime" onchange=fightSettings() value="0.6"></li>
-          <li><label class="label-2">% of Fight Weaved</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey fight-setting-input-3" id="weavepercent" onchange=fightSettings() value="100"> %</li>
+          <li><label class="label-2">Trap Weave Time (s)</label><input type="number" step="0.1" min="0" max="2" class="number-input hover-grey fight-setting-input-3" id="weavetime" onchange=fightSettings() value="0.6"></li>
           <br>
           <li>
             <label class="label-2">Target</label>
@@ -801,9 +800,9 @@
           <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_hunter_snipershot.jpg" alt=""><label class="label-4">Hunter's Mark</label>
             <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="hmuptime" onchange=auraUptimeSettings() value="100"> %</li>
             <li><label class="label-5">HM - Bonus</label><select id="hmbonus" onchange=auraUptimeSettings() class="select hover-grey select-imp-auras-2">
-              <option value="glyph">Glyph & Talented</option>
-              <option value="talent">Talented</option>
-              <option selected value="base">Base</option>
+              <option value="2">Glyph & Talented</option>
+              <option value="1">Talented</option>
+              <option selected value="0">Base</option>
             </select>
           <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_righteousnessaura.jpg" alt=""><label class="label-4">Judgement of Wisdom</label>
             <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="jowuptime" onchange=auraUptimeSettings() value="98"> %</li>
@@ -865,7 +864,7 @@
 
           <div class="relative-wrapper-spells">
             <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_potion_108.jpg" alt="">
-            <li><label class="container container-2 container-adjust-top">Primary Potion (Haste)<input id="hastecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+            <li><label class="container container-2 container-adjust-top">Primary Potion<input id="potioncheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
             <input id="startpotoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
           </div>
           <div class="relative-wrapper-spells">
@@ -906,12 +905,18 @@
         <li>
           <label class="label-3">Preset Talent Options</label>
             <select id="talentselect" onchange="selectTalents(this.value)" class="select hover-grey select-relative">
-              <option selected value="6">BM Imp HM Tracking</option>
-              <option value="5">MM ImpHM Focused Aim</option>
-              <option value="4">MM ImpArcane Focused Aim</option>
-              <option value="3">SV Focused Aim Resrc Aimed Shot</option>
-              <option value="2">BM Focused Aim Tracking</option>
-              <option value="1">BM Focused Aim Tracking</option>
+              <option selected value="bm70">BM 70 no Hit</option>
+              <option value="bm70hit">BM 70 3% Hit</option>
+              <option value="mm70">MM 70 no Hit</option>
+              <option value="mm70hit">MM 70 3% Hit</option>
+              <option value="sv70">SV 70 no Hit</option>
+              <option value="sv70hit">SV 70 3% Hit</option>
+              <option value="bm80">BM 80 no Hit</option>
+              <option value="bm80hit">BM 80 3% Hit</option>
+              <option value="mm80">MM 80 no Hit</option>
+              <option value="mm80hit">MM 80 3% Hit</option>
+              <option value="sv80">SV 80 no Hit</option>
+              <option value="sv80hit">SV 80 3% Hit</option>
               <option value="0">Custom link (see below)</option>
             </select>
         </li>
@@ -996,11 +1001,12 @@
         <label class="container container-3">Crafted<input type="checkbox" id="craftcheck" onchange=updateGearLists()><span class="checkmark"></span></label>
       </div>
       <select class="select hover-grey select-filters" id="phasecheck" onchange=updateGearLists()>
-        <option selected value="5">Phase 5</option>
+        <option value="5">Phase 5</option>
         <option value="4">Phase 4</option>
         <option value="3">Phase 3</option>
         <option value="2">Phase 2</option>
         <option value="1">Phase 1</option>
+        <option selected value="0">Phase 0</option>
       </select>
     </div>
     <ul class="item-selector">

--- a/js/aurahandling.js
+++ b/js/aurahandling.js
@@ -5,15 +5,15 @@ var beastwithinreduc = 1;
 var sharedtrinketcd = 0;
 
 var debuffs = {
-    hm: {uptime_g:100, timer:0, duration:300, improved:false, rap:110, uptime:0},
-    judgewisdom: {uptime_g:100, timer:0, duration:20, uptime:0},
-    judgecrusader: {uptime_g:0, timer:0, duration:20, crit:3, uptime:0},
-    sunder: {uptime_g:0, timer:0, duration:30, stacktime:5, stacks:1, arp:0.04, uptime:0},
-    faeriefire: {uptime_g:0, timer:0, duration:300, arp:0.05, uptime:0},
+    hm: {uptime_g:95, timer:0, duration:300, improved:0, rap:110, uptime:0},
+    judgewisdom: {uptime_g:95, timer:0, duration:20, uptime:0},
+    judgecrusader: {uptime_g:95, timer:0, duration:20, crit:3, uptime:0},
+    sunder: {uptime_g:95, timer:0, duration:30, stacktime:5, stacks:1, arp:0.04, uptime:0},
+    faeriefire: {uptime_g:95, timer:0, duration:300, arp:0.05, uptime:0},
     expose: {uptime_g:0, timer:0, duration:30, arp:0.2, uptime:0},
-    bloodfrenzy: {uptime_g:0, timer:0, duration:12, dmgbonus:1.04, uptime:0},
-    curseofele: {uptime_g:0, timer:0, duration:120, dmgbonus:1.13, uptime:0},
-    mangle: {uptime_g:0, timer:0, duration:60, dmgbonus:1.3, uptime:0}
+    bloodfrenzy: {uptime_g:95, timer:0, duration:12, dmgbonus:1.04, uptime:0},
+    curseofele: {uptime_g:95, timer:0, duration:120, dmgbonus:1.13, uptime:0},
+    mangle: {uptime_g:95, timer:0, duration:60, dmgbonus:1.3, uptime:0}
 }
 
 var buff_uptimes = {}
@@ -36,7 +36,9 @@ function initializeAuras() {
     Object.values(auras).forEach(key => key.uptime = 0);
     Object.values(debuffs).forEach(key => key.uptime = 0);
     
-    debuffs.hm.rap = (level === 70) ? 110 : 500;
+    let HM_AP_70 = 110;
+    let HM_AP_80 = 500;
+    debuffs.hm.rap = (level === 70) ? HM_AP_70 : HM_AP_80;
 
     auratimers = buildAuraTimerSteps(auras)
     auracds = buildAuraCdSteps(auras)
@@ -58,7 +60,7 @@ function initializeAuras() {
     
     aura_cd_resets(auras)
     aura_timer_resets(auras)
-    
+    if (auras.pierce_shot?.damage > 0) auras.pierce_shot.damage = 0;
     debuffs.hm.timer = 0;
     debuffs.judgewisdom.timer = 0;
     debuffs.judgecrusader.timer = 0;
@@ -587,7 +589,7 @@ function dotHandler(dotname, source, apply, type, crit_dmg) {
             updateDmgMod(dotname);
             result = 0;
             let ticks = auras[dotname].effect.duration / auras[dotname].effect.tick_rate;
-            dmg = auras[dotname].damage / ticks * bleeddmgmod;
+            dmg = auras[dotname].damage / ticks * bleeddmgmod * physdmgmod;
             //console.log(dottype)
         }
         else if (dotname === 'explosiveshot') { // rolled like a spell each hit

--- a/js/data/auras.js
+++ b/js/data/auras.js
@@ -1420,20 +1420,27 @@ function updateUsableCDs() {
     let profession_1 = 'Tailoring';
     let profession_2 = 'Leatherworking';
 
+    let rapidcheck = document.getElementById("rapidcheck").checked;
+    let lustcheck = document.getElementById("lustcheck").checked;
+    let runecheck = document.getElementById("runecheck").checked;
+    let beastwithincheck = document.getElementById("beastcheck").checked;
+    let racialcheck = document.getElementById("racialcheck").checked;
+    let potioncheck = document.getElementById("potioncheck").checked;
+
     if (selectedRace == 3) { // orc
-        usable_CDs.bloodfury.enable = true; // fixme
+        usable_CDs.bloodfury.enable = racialcheck; // fixme
         usable_CDs.berserking.enable = false;
         usable_CDs.arcanetorrent.enable = false;
 
     } else if (selectedRace == 4){ // troll
-        usable_CDs.berserking.enable = true;
+        usable_CDs.berserking.enable = racialcheck;
         usable_CDs.bloodfury.enable = false;
         usable_CDs.arcanetorrent.enable = false;
 
     } else if (selectedRace == 6){ // blood elf
         usable_CDs.berserking.enable = false;
         usable_CDs.bloodfury.enable = false;
-        usable_CDs.arcanetorrent.enable = true;
+        usable_CDs.arcanetorrent.enable = racialcheck;
 
     } else {
         usable_CDs.berserking.enable = false;
@@ -1460,15 +1467,16 @@ function updateUsableCDs() {
         usable_CDs.furious_howl.enable = false;
         usable_CDs.serenitydust.enable = false;
     }
-
+    
     usable_CDs.readiness.enable = (talents.readiness > 0) ? true : false;
     usable_CDs.recovery.enable = (pet_talents.roar_recovery > 0) ? true : false;
     usable_CDs.callofwild.enable = (pet_talents.call_of_wild > 0) ? true : false;
     usable_CDs.rabid.enable = (pet_talents.rabid > 0) ? true : false;
-    usable_CDs.rune.enable = true;
-    usable_CDs.rapid.enable = true;
-    usable_CDs.lust.enable = true;
-    usable_CDs.beastwithin.enable = (talents.beast_within > 0) ? true : false;
+    usable_CDs.rune.enable = runecheck;
+    usable_CDs.rapid.enable = rapidcheck;
+    usable_CDs.lust.enable = lustcheck;
+    usable_CDs.beastwithin.enable = (talents.beast_within > 0) ? beastwithincheck : false;
+    usable_CDs.potion.enable = potioncheck;
     usable_CDs.potion.potion_type = 'Crit'
     
 }
@@ -1580,8 +1588,9 @@ function buildAurasObj(){
         let slot = ENCHANT_AURAS[aura_].slot;
         let checkitem = false;
         if (slot === 'attachment') {
-            if ((gear.offhand === undefined) && (gear.mainhand.attachment > 1)) 
+            if ((gear.offhand === undefined) || !(gear.offhand.attachment) && (gear.mainhand.attachment > 1)) {
                 checkitem = (gear.mainhand.attachment === req);
+            }
             else if(mainhandcheck && offhandcheck){
                 checkitem = (gear.mainhand.attachment === req || gear.offhand.attachment === req);
             } else {
@@ -1713,6 +1722,39 @@ function buildAurasObj(){
     return;
 }
 
+function buildAurasAP(auras) {
+    const conds = Object.keys(auras).map(k =>
+       `if(auras.${k}.timer == 0) {
+           if (!!auras.${k}.stacks) bonusAP += auras.${k}.stacks * auras.${k}.effect.stats.RAP
+           else bonusAP += auras.${k}.effect.stats.RAP
+        }`) 
+    return eval(`(function(auras, bonusAP) {${conds.join(';\n')}})`)
+}
+
+function buildAurasHaste(auras) {
+    const conds = Object.keys(auras).map(k =>
+      `if(auras.${k}.timer > 0) auras.${k}.timer = Math.max(auras.${k}.timer - steptime,0)`)
+    return eval(`(function(auras) {${conds.join(';\n')}})`)
+}
+
+function buildAurasCrit(auras) {
+    const conds = Object.keys(auras).map(k =>
+      `if(auras.${k}.timer > 0) auras.${k}.timer = Math.max(auras.${k}.timer - steptime,0)`)
+    return eval(`(function(auras) {${conds.join(';\n')}})`)
+}
+
+function buildAurasArP(auras) {
+    const conds = Object.keys(auras).map(k =>
+      `if(auras.${k}.timer > 0) auras.${k}.timer = Math.max(auras.${k}.timer - steptime,0)`)
+    return eval(`(function(auras) {${conds.join(';\n')}})`)
+}
+
+function buildAurasAgi(auras) {
+    const conds = Object.keys(auras).map(k =>
+      `if(auras.${k}.timer > 0) auras.${k}.timer = Math.max(auras.${k}.timer - steptime,0)`)
+    return eval(`(function(auras) {${conds.join(';\n')}})`)
+}
+
 function buildAuraTimerSteps(auras) {
     const conds = Object.keys(auras).map(k =>
       `if(auras.${k}.timer > 0) auras.${k}.timer = Math.max(auras.${k}.timer - steptime,0)`)
@@ -1748,3 +1790,4 @@ var auracds = buildAuraCdSteps(auras)
 var aurauptimes = buildAuraUptimeSteps(auras)
 var aura_timer_resets = buildAuraTimerResets(auras)
 var aura_cd_resets = buildAuraCdResets(auras)
+var aura_sum_ap = buildAurasAP(ap_auras)

--- a/js/data/enchants.js
+++ b/js/data/enchants.js
@@ -5,7 +5,7 @@ const HEAD_ENCHANTS = {
     stats: {
         Haste: 10
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Uncommon",
     icon: 'inv_misc_gem_02',
     desc: '+10 Haste'
@@ -18,7 +18,7 @@ const HEAD_ENCHANTS = {
       Hit: 10,
       RAP: 24
     },
-    Phase: 1,
+    Phase: 0,
     icon: 'spell_nature_forceofnature',
     quality: "Rare",
     desc: '+10 Stam, +10 Hit, +24 RAP'
@@ -31,7 +31,7 @@ const HEAD_ENCHANTS = {
         RAP: 34,
         Hit: 16
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Uncommon",
     icon: 'classic_ability_druid_demoralizingroar',
     desc: '+34 AP, +16 Hit'
@@ -43,7 +43,7 @@ const HEAD_ENCHANTS = {
         Stam: 18,
         Resil: 20
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Uncommon",
     icon: 'inv_misc_statue_04',
     desc: '+18 Stam, +20 Resil'
@@ -108,7 +108,7 @@ const SHOULDER_ENCHANTS = {
       RAP: 20,
       Crit: 15
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'spell_holy_weaponmastery',
     desc: '+20 AP, +15 Crit'
@@ -121,7 +121,7 @@ const SHOULDER_ENCHANTS = {
       RAP: 30,
       Crit: 10
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'spell_holy_greaterblessingofkings',
     desc: '+30 AP, +10 Crit'
@@ -170,7 +170,7 @@ const SHOULDER_ENCHANTS = {
       RAP: 26,
       Crit: 14
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Epic",
     icon: 'spell_shadow_deathpact',
     desc: '+26 AP, +14 Crit'
@@ -210,7 +210,7 @@ const BACK_ENCHANTS = {
     stats: {
       Agi: 12
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+12 Agi'
@@ -300,7 +300,7 @@ const CHEST_ENCHANTS = {
     stats: {
       Health: 150
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+150 HP'
@@ -309,12 +309,12 @@ const CHEST_ENCHANTS = {
     name: 'Exceptional Mana',
     effectId: 2660,
     stats: {
-      Mana: 150
+      Mana: 250
     },
     Phase: 1,
     quality: "Common",
     icon: 'trade_engraving',
-    desc: '+150 Mana'
+    desc: '+250 Mana'
   },
   27960: {
     name: 'Exceptional Stats',
@@ -326,7 +326,7 @@ const CHEST_ENCHANTS = {
       Spi: 6,
       Int: 6
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+6 All Stats'
@@ -396,10 +396,10 @@ const CHEST_ENCHANTS = {
     stats: {
       MP5: 7
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
-    desc: '+6 Mp5'
+    desc: '+7 Mp5'
   },
   60692: {
     name: 'Powerful Stats',
@@ -438,7 +438,7 @@ const WRIST_ENCHANTS = {
       MAP: 24,
       RAP: 24
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+24 AP'
@@ -601,7 +601,7 @@ const HAND_ENCHANTS = {
     stats: {
       Agi: 15
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+15 Agi'
@@ -661,7 +661,7 @@ const LEG_ENCHANTS = {
       Agi: 10,
       Stam: 30
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'inv_misc_armorkit_23',
     desc: '+10 Agi, +30 Stam'
@@ -674,7 +674,7 @@ const LEG_ENCHANTS = {
       RAP: 40,
       Crit: 10
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'inv_misc_armorkit_21',
     desc: '+40 AP, +10 Crit'
@@ -697,7 +697,7 @@ const LEG_ENCHANTS = {
       Agi: 12,
       Stam: 40
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Epic",
     icon: 'inv_misc_armorkit_25',
     desc: '+12 Agi, +40 Stam'
@@ -710,7 +710,7 @@ const LEG_ENCHANTS = {
       RAP: 50,
       Crit: 12
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Epic",
     icon: 'inv_misc_armorkit_25',
     desc: '+50 AP, +12 Crit'
@@ -805,16 +805,74 @@ const LEG_ENCHANTS = {
 }
 
 const FEET_ENCHANTS = {
-  13935: {
-    name: 'Agility',
-    effectId: 904,
+  47901: {
+    name: "Tuskarr's Vitality",
+    effectId: 3232,
     stats: {
-      Agi: 5
+      Stam: 15
     },
     Phase: 1,
     quality: "Common",
     icon: 'trade_engraving',
-    desc: '+5 Agi'
+    desc: '+15 Stam, 8% Speed'
+  },
+  60763: {
+    name: "Greater Assault",
+    effectId: 1597,
+    stats: {
+      MAP: 32,
+      RAP: 32
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'trade_engraving',
+    desc: '+32 AP'
+  },
+  44589: {
+    name: "Superior Agility",
+    effectId: 983,
+    stats: {
+      Agi: 16
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'trade_engraving',
+    desc: '+16 Agi'
+  },
+  60623: {
+    name: "Icewalker",
+    effectId: 3826,
+    stats: {
+      Hit: 12,
+      Crit: 12
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'trade_engraving',
+    desc: '+12 Hit, +12 Crit'
+  },
+  44528: {
+    name: "Greater Fortitude",
+    effectId: 1075,
+    stats: {
+      Stam: 22
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'trade_engraving',
+    desc: '+22 Stam'
+  },
+  60606: {
+    name: "Assault",
+    effectId: 3824,
+    stats: {
+      MAP: 24,
+      RAP: 24
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'trade_engraving',
+    desc: '+24 AP'
   },
   34008: {
     name: "Boar's Speed",
@@ -823,7 +881,7 @@ const FEET_ENCHANTS = {
     stats: {
       Stam: 9,
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+9 Stam, +8% Speed'
@@ -835,7 +893,7 @@ const FEET_ENCHANTS = {
     stats: {
       Agi: 6,
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+6 Agi, +8% Speed'
@@ -846,7 +904,7 @@ const FEET_ENCHANTS = {
     stats: {
       Agi: 12
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+12 Agi'
@@ -857,7 +915,7 @@ const FEET_ENCHANTS = {
     stats: {
       Stam: 12
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+12 Stam'
@@ -868,7 +926,7 @@ const FEET_ENCHANTS = {
     stats: {
       Agi: 7
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+7 Agi'
@@ -888,28 +946,40 @@ const FEET_ENCHANTS = {
     name: 'Surefooted',
     effectId: 2658,
     stats: {
-      Hit: 10
+      Hit: 10,
+      Crit: 10
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
-    desc: '+10 Hit'
-  },
-  27948: {
-    name: 'Vitality',
-    effectId: 2656,
-    stats: {
-      MP5: 4,
-      HP5: 4
-    },
-    Phase: 1,
-    quality: "Common",
-    icon: 'trade_engraving',
-    desc: '+4 Mp5, 4 Hp5'
+    desc: '+10 Hit, +10 Crit'
   }
 }
 
 const RING_ENCHANTS = {
+  44645: {
+    name: 'Assault',
+    effectId: 3839,
+    stats: {
+      MAP: 40,
+      RAP: 40
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+40 AP'
+  },
+  59636: {
+    name: 'Stamina',
+    effectId: 3791,
+    stats: {
+      Stam: 30
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+30 Stam'
+  },
   27927: {
     name: 'Stats',
     effectId: 2931,
@@ -920,31 +990,105 @@ const RING_ENCHANTS = {
       Spi: 4,
       Int: 4
     },
-    Phase: 3,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_misc_note_01',
     desc: '+4 All Stats'
-  },
-  27920: {
-    name: 'Striking',
-    effectId: 2929,
-    special: { dmgbonus: 2 },
-    stats: {},
-    Phase: 1,
-    quality: "Common",
-    icon: 'inv_misc_note_01',
-    desc: '+2 Damage'
   }
 }
 
 const MELEE_ENCHANTS = {
+  59619: {
+    name: 'Accuracy',
+    effectId: 3788,
+    stats: {
+      Hit: 25,
+      Crit: 25
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+25 Hit, +25 Crit'
+  },
+  60707: {
+    name: 'Superior Potency',
+    effectId: 3833,
+    stats: {
+      MAP: 65,
+      RAP: 65
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+65 AP'
+  },
+  60691: {
+    name: 'Massacre (2H)',
+    effectId: 3827,
+    for_two_handed: true,
+    stats: {
+      MAP: 110,
+      RAP: 110
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+110 AP'
+  },
+  44595: {
+    name: 'Scourgebane (2H)',
+    effectId: 3247,
+    for_two_handed: true,
+    stats: {
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+140 AP to Undead' 
+  },
+  44633: {
+    name: 'Exceptional Agility',
+    effectId: 1103,
+    stats: {
+      Agi: 26
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+26 Agi'
+  },
+  44630: {
+    name: 'Greater Savagery (2H)',
+    effectId: 3828,
+    for_two_handed: true,
+    stats: {
+      MAP: 85,
+      RAP: 85
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+85 AP'
+  },
+  60621: {
+    name: 'Superior Potency',
+    effectId: 1606,
+    stats: {
+      MAP: 50,
+      RAP: 50
+    },
+    Phase: 1,
+    quality: "Common",
+    icon: 'inv_misc_note_01',
+    desc: '+50 AP'
+  },
   23800: {
     name: 'Agility',
     effectId: 2564,
     stats: {
       Agi: 15,
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_misc_note_01',
     desc: '+15 Agi'
@@ -956,7 +1100,7 @@ const MELEE_ENCHANTS = {
     stats: {
       Agi: 25,
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_misc_note_01',
     desc: '+25 Agi (2H)'
@@ -967,7 +1111,7 @@ const MELEE_ENCHANTS = {
     stats: {
       Agi: 20
     },
-    Phase: 3,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_misc_note_01',
     desc: '+20 Agi'
@@ -979,7 +1123,7 @@ const MELEE_ENCHANTS = {
     stats: {
       Agi: 35
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+35 Agi (2H)'
@@ -990,7 +1134,7 @@ const MELEE_ENCHANTS = {
     stats: {
       Int: 30
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+30 Int'
@@ -1001,21 +1145,10 @@ const MELEE_ENCHANTS = {
     stats: {
       Int: 22
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_misc_note_01',
     desc: '+22 Int'
-  },
-  27972: {
-    name: 'Potency',
-    effectId: 2668,
-    stats: {
-      Str: 20
-    },
-    Phase: 1,
-    quality: "Common",
-    icon: 'trade_engraving',
-    desc: '+20 Str'
   },
   27971: {
     name: 'Savagery (2H)',
@@ -1025,79 +1158,46 @@ const MELEE_ENCHANTS = {
       MAP: 70,
       RAP: 70
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'trade_engraving',
     desc: '+70 AP (2H)'
-  },
-  23799: {
-    name: 'Strength',
-    effectId: 2563,
-    stats: {
-      Str: 15
-    },
-    Phase: 1,
-    quality: "Common",
-    icon: 'inv_misc_note_01',
-    desc: '+15 Str'
-  },
-  27984: {
-    name: 'Mongoose',
-    effectId: 2673,
-    aura: {
-      stats: {
-        Agi: 120,
-        Haste: 30
-      },
-      duration: 15,
-      PPM: 1,
-      proc_type: 4
-    },
-    Phase: 1,
-    quality: "Common",
-    icon: 'trade_engraving',
-    desc: 'Proc +120 Agi for 15s'
-  },
-  42974: {
-    name: 'Executioner',
-    effectId: 3225,
-    aura: {
-      stats: {
-        ArP: 840,
-      },
-      duration: 15,
-      PPM: 1,
-      proc_type: 4
-    },
-    Phase: 4,
-    quality: "Common",
-    icon: 'trade_engraving',
-    desc: 'Proc +840 ArP for 15s'
   }
 }
 
 const RANGE_ENCHANTS = {
-  3976: {
-    name: 'Accurate Scope',
-    effectId: 33,
-    special: {
-      rangedmgbonus: 3
+  55135: {
+    name: 'Heartseeker Scope',
+    effectId: 3608,
+    stats: {
+      RangeCrit: 28
     },
     Phase: 1,
     quality: "Common",
     icon: 'trade_engineering',
-    desc: '+3 Ranged Weapon Damage'
+    desc: '+40 Ranged Crit'
   },
-  12459: {
-    name: 'Deadly Scope',
-    effectId: 663,
-    special: {
-      rangedmgbonus: 5
+  55076: {
+    name: 'Sun Scope',
+    effectId: 3607,
+    stats: {
+      Haste: 40
     },
     Phase: 1,
     quality: "Common",
     icon: 'trade_engineering',
-    desc: '+5 Ranged Weapon Damage'
+    desc: '+40 Ranged Haste'
+  },
+  61468: {
+    name: 'Diamond Cut Refractor Scope',
+    effectId: 3843,
+    special: {
+      rangedmgbonus: 15
+    },
+    Phase: 1,
+    quality: "Rare",
+    icon: 'trade_engineering',
+    desc: '+15 Ranged Weapon Damage'
   },
   22779: {
     name: 'Biznicks 247x128 Accurascope',
@@ -1105,7 +1205,7 @@ const RANGE_ENCHANTS = {
     stats: {
       RangeHit: 30
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'trade_engineering',
     desc: '+30 Ranged Hit'
@@ -1116,21 +1216,10 @@ const RANGE_ENCHANTS = {
     special: {
       rangedmgbonus: 12
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'trade_engineering',
     desc: '+12 Ranged Weapon Damage'
-  },
-  12460: {
-    name: 'Sniper Scope',
-    effectId: 664,
-    special: {
-      rangedmgbonus: 7
-    },
-    Phase: 1,
-    quality: "Common",
-    icon: 'trade_engineering',
-    desc: '+7 Ranged Weapon Damage'
   },
   30260: {
     name: 'Stabilitzed Eternium Scope',
@@ -1138,7 +1227,7 @@ const RANGE_ENCHANTS = {
     stats: {
       RangeCrit: 28
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Rare",
     icon: 'trade_engineering',
     desc: '+28 Ranged Crit'
@@ -1148,6 +1237,15 @@ const RANGE_ENCHANTS = {
 const ATTACHMENTS = {
   1:{
     name: 'None',
+  },
+  23122: {
+    name: 'Consecrated Weapon (ilvl 165)',
+    effectId: 2955,
+    stats: {
+    },
+    Phase: 0,
+    quality: "Uncommon",
+    icon: 'inv_stone_sharpeningstone_02'
   },
   28421: {
     name: 'Adamantite Weightstone',
@@ -1161,12 +1259,12 @@ const ATTACHMENTS = {
       dmgbonus: 12,
     },
     type: 'blunt',
-    Phase: 1,
+    Phase: 0,
     quality: "Uncommon",
     icon: 'inv_stone_weightstone_07'
   },
   23529: {
-    name: 'Adamantite Sharpening Stone',
+    name: 'Adamantite Sharpening Stone (ilvl 165)',
     effectId: 2713,
     stats: {
       MeleeCrit: 14
@@ -1176,24 +1274,24 @@ const ATTACHMENTS = {
       dmgbonus: 12,
     },
     type: 'sharp',
-    Phase: 1,
+    Phase: 0,
     quality: "Uncommon",
     icon: 'inv_stone_sharpeningstone_07'
   },
   22521: {
-    name: 'Superior Mana Oil',
+    name: 'Superior Mana Oil (ilvl 165)',
     effectId: 2677,
     stats: {
       MP5: 14
     },
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_potion_101'
   },
   34539: {
-    name: 'Righteous Weapon Coating',
+    name: 'Righteous Weapon Coating (ilvl 165)',
     effectId: 3266,
-    Phase: 1,
+    Phase: 0,
     quality: "Common",
     icon: 'inv_potion_101'
   },

--- a/js/data/gems.js
+++ b/js/data/gems.js
@@ -7,7 +7,7 @@ const GEMS = {
           "blue"
       ],
       stats: {},
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_enchant_voidsphere"
   },
@@ -19,7 +19,7 @@ const GEMS = {
       stats: {
           Agi: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_bloodgem_02"
   },
@@ -33,7 +33,7 @@ const GEMS = {
           Agi: 3,
           Hit: 3
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_flamespessarite_02"
   },
@@ -47,7 +47,7 @@ const GEMS = {
           Stam: 4,
           Crit: 3
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_deepperidot_02"
   },
@@ -61,7 +61,7 @@ const GEMS = {
           Int: 3,
           MP5: 1
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_deepperidot_02"
   },
@@ -75,7 +75,7 @@ const GEMS = {
           Agi: 3,
           Stam: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_ebondraenite_02"
   },
@@ -87,7 +87,7 @@ const GEMS = {
       stats: {
           Int: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_goldendraenite_02"
   },
@@ -99,7 +99,7 @@ const GEMS = {
       stats: {
           Hit: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_goldendraenite_02"
   },
@@ -111,7 +111,7 @@ const GEMS = {
       stats: {
           Stam: 9
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_azuredraenite_02"
   },
@@ -123,7 +123,7 @@ const GEMS = {
       stats: {
           MP5: 2
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_azuredraenite_02"
   },
@@ -135,7 +135,7 @@ const GEMS = {
       stats: {
           Agi: 8
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_livingruby_03"
   },
@@ -148,7 +148,7 @@ const GEMS = {
           MAP: 16,
           RAP: 16
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_livingruby_03"
   },
@@ -160,7 +160,7 @@ const GEMS = {
       stats: {
           Stam: 12
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_starofelune_03"
   },
@@ -172,7 +172,7 @@ const GEMS = {
       stats: {
           MP5: 3
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_starofelune_03"
   },
@@ -184,7 +184,7 @@ const GEMS = {
       stats: {
           Int: 8
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_dawnstone_03"
   },
@@ -196,7 +196,7 @@ const GEMS = {
       stats: {
           Crit: 8
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_dawnstone_03"
   },
@@ -208,7 +208,7 @@ const GEMS = {
       stats: {
           Hit: 8
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_dawnstone_03"
   },
@@ -220,7 +220,7 @@ const GEMS = {
       stats: {
           Resil: 8
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_dawnstone_03"
   },
@@ -234,7 +234,7 @@ const GEMS = {
           Agi: 4,
           Stam: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_nightseye_03"
   },
@@ -248,7 +248,7 @@ const GEMS = {
           Agi: 4,
           Hit: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
@@ -262,7 +262,7 @@ const GEMS = {
           Int: 4,
           MP5: 2
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_talasite_03"
   },
@@ -276,7 +276,7 @@ const GEMS = {
           Stam: 6,
           Crit: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_talasite_03"
   },
@@ -295,7 +295,7 @@ const GEMS = {
 
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_07",
       desc: "1 Red, 2 Yellow"
@@ -312,7 +312,7 @@ const GEMS = {
         }
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_07",
       desc: "More Red than Yellow"
@@ -329,7 +329,7 @@ const GEMS = {
         }
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_06",
       desc: "3 Blue"
@@ -346,7 +346,7 @@ const GEMS = {
         }
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_06",
       desc: "2 Red, 2 Yellow, 2 Blue"
@@ -359,7 +359,7 @@ const GEMS = {
       stats: {
           Resil: 10
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_misc_gem_topaz_01"
@@ -374,7 +374,7 @@ const GEMS = {
           Stam: 3,
           Crit: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       unique: true,
       icon: "inv_misc_gem_deepperidot_01"
@@ -387,7 +387,7 @@ const GEMS = {
       stats: {
           Crit: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_goldendraenite_02"
   },
@@ -400,7 +400,7 @@ const GEMS = {
           MAP: 14,
           RAP: 14
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       unique: true,
       icon: "inv_misc_gem_bloodstone_02"
@@ -419,7 +419,7 @@ const GEMS = {
 
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_07",
       desc: "2 Yellow, 1 Red"
@@ -433,7 +433,7 @@ const GEMS = {
           MAP: 12,
           RAP: 12
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_bloodgem_02"
   },
@@ -447,7 +447,7 @@ const GEMS = {
           Agi: 5,
           Stam: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nightseye_03"
@@ -462,7 +462,7 @@ const GEMS = {
           Crit: 5,
           MP5: 2
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_talasite_03"
@@ -478,7 +478,7 @@ const GEMS = {
           RAP: 10,
           Hit: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nobletopaz_03"
@@ -493,7 +493,7 @@ const GEMS = {
           Agi: 5,
           Hit: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nobletopaz_03"
@@ -509,7 +509,7 @@ const GEMS = {
           MAP: 10,
           RAP: 10
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nightseye_03"
@@ -525,7 +525,7 @@ const GEMS = {
           RAP: 8,
           Crit: 5
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nobletopaz_03"
@@ -540,7 +540,7 @@ const GEMS = {
           Stam: 6,
           Int: 5
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_talasite_03"
@@ -555,7 +555,7 @@ const GEMS = {
           Int: 5,
           MP5: 2
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_talasite_03"
@@ -571,7 +571,7 @@ const GEMS = {
           RAP: 8,
           Resil: 5
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nobletopaz_03"
@@ -586,7 +586,7 @@ const GEMS = {
           Stam: 6,
           Resil: 5
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_talasite_03"
@@ -601,7 +601,7 @@ const GEMS = {
           Stam: 6,
           Crit: 5
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_talasite_03"
@@ -617,7 +617,7 @@ const GEMS = {
           MAP: 10,
           RAP: 10
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nightseye_03"
@@ -633,7 +633,7 @@ const GEMS = {
           MAP: 6,
           RAP: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_ebondraenite_02"
   },
@@ -648,7 +648,7 @@ const GEMS = {
           MAP: 8,
           RAP: 8
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_nightseye_03"
   },
@@ -663,7 +663,7 @@ const GEMS = {
           RAP: 6,
           MP5: 1
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_ebondraenite_02"
   },
@@ -678,7 +678,7 @@ const GEMS = {
           RAP: 8,
           MP5: 2
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_nightseye_03"
   },
@@ -693,7 +693,7 @@ const GEMS = {
           RAP: 8,
           Crit: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
@@ -708,7 +708,7 @@ const GEMS = {
           RAP: 6,
           Crit: 3
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Uncommon",
       icon: "inv_misc_gem_flamespessarite_02"
   },
@@ -720,7 +720,7 @@ const GEMS = {
       stats: {
           Agi: 10
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_crimsonspinel_02"
   },
@@ -732,7 +732,7 @@ const GEMS = {
       stats: {
           Stam: 15
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
@@ -744,7 +744,7 @@ const GEMS = {
       stats: {
           MP5: 4
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
@@ -756,7 +756,7 @@ const GEMS = {
       stats: {
           Int: 10
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_lionseye_02"
   },
@@ -768,7 +768,7 @@ const GEMS = {
       stats: {
           Crit: 10
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_lionseye_02"
   },
@@ -780,7 +780,7 @@ const GEMS = {
       stats: {
           Hit: 10
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_lionseye_02"
   },
@@ -792,7 +792,7 @@ const GEMS = {
       stats: {
           Resil: 10
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_lionseye_02"
   },
@@ -806,7 +806,7 @@ const GEMS = {
           Agi: 5,
           Stam: 7
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
@@ -821,7 +821,7 @@ const GEMS = {
           MAP: 10,
           RAP: 10
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
@@ -836,7 +836,7 @@ const GEMS = {
           RAP: 10,
           MP5: 2
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
@@ -850,7 +850,7 @@ const GEMS = {
           Agi: 5,
           Hit: 5
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_pyrestone_02"
   },
@@ -865,7 +865,7 @@ const GEMS = {
           RAP: 10,
           Crit: 5
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_pyrestone_02"
   },
@@ -879,7 +879,7 @@ const GEMS = {
           Int: 5,
           MP5: 2
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_seasprayemerald_02"
   },
@@ -893,7 +893,7 @@ const GEMS = {
           Stam: 7,
           Crit: 5
       },
-      Phase: 3,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_seasprayemerald_02"
   },
@@ -911,7 +911,7 @@ const GEMS = {
 
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_06",
       desc: "2 Red, 2 Yellow, 2 Blue"
@@ -935,7 +935,7 @@ const GEMS = {
         }
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_07",
       desc: "2 Red, 2 Yellow, 2 Blue"
@@ -951,7 +951,7 @@ const GEMS = {
           MAP: 8,
           RAP: 8
       },
-      Phase: 2,
+      Phase: 0,
       quality: "Rare",
       unique: true,
       icon: "inv_jewelcrafting_shadowsongamethyst_01"
@@ -966,7 +966,7 @@ const GEMS = {
           Stam: 6,
           Int: 4
       },
-      Phase: 2,
+      Phase: 0,
       quality: "Rare",
       unique: true,
       icon: "inv_misc_gem_deepperidot_03"
@@ -982,7 +982,7 @@ const GEMS = {
           RAP: 8,
           Crit: 4
       },
-      Phase: 2,
+      Phase: 0,
       quality: "Rare",
       unique: true,
       icon: "inv_misc_gem_opal_01"
@@ -1001,7 +1001,7 @@ const GEMS = {
         
         return { bonus, active }
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_misc_gem_diamond_07",
       desc: "More Blue than Yellow"
@@ -1015,7 +1015,7 @@ const GEMS = {
           MAP: 32,
           RAP: 32
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_crimsonspinel_02"
@@ -1028,7 +1028,7 @@ const GEMS = {
       stats: {
           Stam: 18
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_empyreansapphire_02"
@@ -1041,7 +1041,7 @@ const GEMS = {
       stats: {
           Crit: 12
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_lionseye_02"
@@ -1056,7 +1056,7 @@ const GEMS = {
           Stam: 6,
           Resil: 4
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Rare",
       icon: "inv_jewelcrafting_talasite_03"
   },
@@ -1068,7 +1068,7 @@ const GEMS = {
       stats: {
           Stam: 15
       },
-      Phase: 4,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_misc_gem_pearl_07"
@@ -1082,7 +1082,7 @@ const GEMS = {
         MAP: 20,
         RAP: 20
     },
-    Phase: 3,
+    Phase: 0,
     quality: "Epic",
     icon: "inv_jewelcrafting_crimsonspinel_02"
   },
@@ -1095,7 +1095,7 @@ const GEMS = {
           MAP: 20,
           RAP: 20
       },
-      Phase: 5,
+      Phase: 0,
       quality: "Epic",
       icon: "inv_jewelcrafting_crimsonspinel_02"
   },
@@ -1108,7 +1108,7 @@ const GEMS = {
           MAP: 20,
           RAP: 20
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_misc_gem_ruby_02"
@@ -1124,7 +1124,7 @@ const GEMS = {
           RAP: 10,
           Crit: 5
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_misc_gem_opal_01"
@@ -1137,7 +1137,7 @@ const GEMS = {
       stats: {
           Crit: 10
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_misc_gem_topaz_01"
@@ -1151,7 +1151,7 @@ const GEMS = {
       stats: {
           Crit: 6
       },
-      Phase: 1,
+      Phase: 0,
       quality: "Epic",
       unique: true,
       icon: "inv_jewelcrafting_nobletopaz_03"

--- a/js/data/glyphs.js
+++ b/js/data/glyphs.js
@@ -4,119 +4,139 @@ const GLYPHS_DATA = {
         name: 'Glyph of Aimed Shot',
         abrv:'aimed_shot',
         bonus: 2,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42898:{
         name: 'Glyph of Arcane Shot',
         abrv:'arcane_shot',
         bonus: 0.2,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42901:{
         name: 'Glyph of Aspect of the Viper',
         abrv:'aspect_viper',
         bonus: 10,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     }, 
     42902:{
         name: 'Glyph of Bestial Wrath',
         abrv:'bestial_wrath',
         bonus: 20,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },        
     45625:{
         name: 'Glyph of Chimera Shot',
         abrv:'chimera_shot',
         bonus: 1,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },       
     45731:{
         name: 'Glyph of Explosive Shot',
         abrv:'explosive_shot',
         bonus: 4,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     45733:{
         name: 'Glyph of Explosive Trap',
         abrv:'explosive_trap',
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42907:{
         name: 'Glyph of Hunter\'s Mark',
         abrv:'hunters_mark',
         bonus: 0.2,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42908:{
         name: 'Glyph of Immolation Trap',
         abrv:'immolate_trap',
         bonus: 6,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     45732:{
         name: 'Glyph of Kill Shot',
         abrv:'kill_shot',
         bonus: 6,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42900:{
         name: 'Glyph of Mending',
         abrv:'mending',
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42910:{
         name: 'Glyph of Multi-Shot',
         abrv:'multi_shot',
         bonus: 1,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42911:{
         name: 'Glyph of Rapid Fire',
         abrv:'rapid_fire',
         bonus: 8,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42912:{
         name: 'Glyph of Serpent Sting',
         abrv:'serpent_sting',
         bonus: 6,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 0
     },
     42913:{
         name: 'Glyph of Snake Trap',
         abrv:'snake_trap',
         bonus: 2,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42914:{
         name: 'Glyph of Steady Shot',
         abrv:'steady_shot',
         bonus: 10,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42901:{
         name: 'Glyph of the Beast',
         abrv:'aspect_beast',
         bonus: 2,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42909:{
         name: 'Glyph of the Hawk',
         abrv:'aspect_hawk',
         bonus: 0.06,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42915:{
         name: 'Glyph of Trueshot Aura',
         abrv:'trueshot_aura',
         bonus: 10,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
     42916:{
         name: 'Glyph of Volley',
         abrv:'volley',
         bonus: 20,
-        icon: 'inv_glyph_majorhunter'
+        icon: 'inv_glyph_majorhunter',
+        phase: 1
     },
 }
 
@@ -128,7 +148,10 @@ function selectGlyphs(glyphs_array) {
     let glyphs = {}
     for (let i=0; i < glyphs_array.length; i++) {
         let obj = GLYPHS_DATA[glyphs_array[i]];
-        glyphs[obj.abrv] = (!!obj.bonus) ? obj.bonus : 0;
+        //console.log(glyphs_array)
+        if(!!obj.abrv){
+            glyphs[obj.abrv] = (!!obj.bonus) ? obj.bonus : 0;
+        }
     }
     return glyphs;
 }

--- a/js/data/talents.js
+++ b/js/data/talents.js
@@ -580,8 +580,35 @@ function parseTalents(talentString) {
   return talents
 }
 
-const BM_ImpHM_Track = parseTalents('51200201515012243100531151-0050352-5')
-const MM_ImpHM_FA_Track = parseTalents('-005305131130013233105031351-500003') //502-035335001230013233135031351-5
-const MM_ImpAS_FA_Track = parseTalents('502-035305131030013233135030351-5000002')
-const SV_FA_Resrc_Aimed = parseTalents('-005005-5000032500033330503035001331') // -035305001-5000032500033330533035001331
-const BM_FA_Track = parseTalents('51200201515012243100531151-0350052-5')
+const talent_presets = [
+   '51200201515012233110531151-005005',
+   '51200201515012233110531151-035002',
+   '502-005305131030013233025131051-3',
+   '502-035305101030013233025131051-3',
+   '-005005-5000032500033230502134301321',
+   '-035002-5000032500033230502134301321',
+   '51200201515012233131531351-0053050011',
+   '51200201515012233111531251-0353050011',
+   '502-005305131130013233035131151-5000032',
+   '502-035305131130013233035131151-5000002',
+   '-005305101-5000032500033330532135301321',
+   '-035305101-5000032500033330502134301331',
+];
+
+const BM_70 = parseTalents(talent_presets[0])
+const BM_70_Hit = parseTalents(talent_presets[1])
+
+const MM_70 = parseTalents(talent_presets[2])
+const MM_70_Hit = parseTalents(talent_presets[3])
+
+const SV_70 = parseTalents(talent_presets[4])
+const SV_70_Hit = parseTalents(talent_presets[5])
+
+const BM_80 = parseTalents(talent_presets[6])
+const BM_80_Hit = parseTalents(talent_presets[7])
+
+const MM_80 = parseTalents(talent_presets[8])
+const MM_80_Hit = parseTalents(talent_presets[9])
+
+const SV_80 = parseTalents(talent_presets[10])
+const SV_80_Hit = parseTalents(talent_presets[11])

--- a/js/pet.js
+++ b/js/pet.js
@@ -23,7 +23,7 @@ const BASE_PET = {
 const PetHappiness = 1.25;
 const PetFamilyMod = 1.05; // WotLK all pets have same family dmg mod of 5% idk why
 const PetHunterAPRatio = 0.22;
-const BaseFocusRegen = 25;
+const BaseFocusRegen = 10; // per 1 sec
 // initial pet object - trying something different from how I did player 1 global object instead of a bunch of variables
 var pet = {
     agi: 0,
@@ -31,6 +31,7 @@ var pet = {
     combatap: 0,
     crit: 0,
     combatcrit:0,
+    combatspellcrit: 0,
     dmgmod: 1,
     hit: 0,
     spellhit: 0,
@@ -248,7 +249,7 @@ function procPetFocus(playercrit){
 
 function petUpdateFocus(){
     // focus regen per 5s
-    let regen = pet.focusregen / 5 * steptime;
+    let regen = pet.focusregen * steptime;
     pet.focus += regen;
     //console.log(regen)  
     

--- a/js/player.js
+++ b/js/player.js
@@ -595,6 +595,15 @@ function updateAP() {
    if (target.type === 'Demon'){
       targetAP += (playerconsumes.battle_elixir === 9224) ? 105 : 0;
    }
+   // demonslaying AP
+   if (target.type === 'Undead'){
+      targetAP += (!!gear.mainhand.enchant && gear.mainhand.attachment === 44595) ? 140 : 0;
+   }
+   // demonslaying AP
+   if (target.type === 'Undead'){
+      targetAP += (!!gear.mainhand.attachment && gear.mainhand.attachment === 23122) ? 170 : 0;
+      targetAP += (!!gear.offhand?.attachment && gear.offhand.attachment === 23122) ? 170 : 0;
+   }
    // Hunter's mark
    
    let HM_rap = (debuffs.hm.timer > 0 && !debuffs.hm.inactive) ? debuffs.hm.rap : 0;
@@ -629,7 +638,7 @@ function updateAP() {
    combatRAP += bonusBaseRAP + (bonusAP + targetAP + HM_rap) * rapmod * combat_apmod;
    combatMAP += bonusBaseMAP + (bonusAP + targetAP) * mapmod * combat_apmod;
 
-   //console.log("rap: " + combatRAP);
+   //console.log("rap: " + targetAP);
    // returns AP used in the pet function call
    return bonusBaseRAP + bonusAP * rapmod * combat_apmod;
 }

--- a/js/ui/datastorage.js
+++ b/js/ui/datastorage.js
@@ -157,6 +157,8 @@ function fetchData(){
     repcheck = (localStorage.getItem("repcheck") != null) ? JSON.parse(localStorage.getItem("repcheck")) : repcheck;
     bosscheck = (localStorage.getItem("bosscheck") != null) ? JSON.parse(localStorage.getItem("bosscheck")) : bosscheck;
     craftcheck = (localStorage.getItem("craftcheck") != null) ? JSON.parse(localStorage.getItem("craftcheck")) : craftcheck;
+
+    SavedSets = (localStorage.getItem('sets') != null) ? JSON.parse(localStorage.getItem('sets')) : SavedSets;
     
     /* Display initialization for fetched values */
     // fight settings initialization
@@ -210,7 +212,7 @@ function fetchData(){
 
     document.getElementById("talentselect").value = talentindex;
     document.getElementById("customtalent").value = whtalentlink;
-    selectTalents(talentindex);
+    
     if (selected_glyphs.length >= 1) {
         document.getElementById('glyphSelect1').value = selected_glyphs[0];
     }
@@ -257,9 +259,8 @@ function fetchData(){
     document.getElementById("leathercheck").checked = leathercheck;
     document.getElementById("craftcheck").checked = craftcheck;
     document.getElementById("repcheck").checked = repcheck;
-
-    SavedSets = (localStorage.getItem('sets') != null) ? JSON.parse(localStorage.getItem('sets')) : SavedSets;
-
+    
+    selectTalents(talentindex);
     // initialize the settings after loading
     selectedOptionsResults();
 }

--- a/js/ui/gearui.js
+++ b/js/ui/gearui.js
@@ -485,22 +485,29 @@ function updateGearLists(){
 
     onehandfilter = document.getElementById("1hfilter").checked;
     twohandfilter = document.getElementById("2hfilter").checked;
-    if (phase >= 3) {
+    if (phase >= 3 && level == 80) {
+        preferredGems = {
+            Red: 40112,
+            Blue: 40130,
+            Yellow: 40147,
+            Meta: 41398
+        }
+    } else if (level == 80) {
+        preferredGems = {
+            Red: 39997,
+            Blue: 40023,
+            Yellow: 40043,
+            Meta: 41398
+        }
+    } else {
         preferredGems = {
             Red: 32194,
             Blue: 32212,
             Yellow: 32222,
             Meta: 32409
         }
-    } else {
-        preferredGems = {
-            Red: 24028,
-            Blue: 24055,
-            Yellow: 31868,
-            Meta: 32409
-        }
     }
-
+    initializeglyphsDropdown();
     storeData();
 
     gearModalDisplay(activeslot);

--- a/js/ui/mainui.js
+++ b/js/ui/mainui.js
@@ -12,7 +12,6 @@ var dpscompare = document.getElementById("dpscompare");
 // disable input for player and pet uptimes
 document.getElementById("playeruptime").disabled = true;
 document.getElementById("petuptime").disabled = true;
-document.getElementById("weavepercent").disabled = true;
 
 // show the stats on the HTML
 function displayStats(){
@@ -453,8 +452,8 @@ initializePetFoodDropdown();
 initializeFlaskDropdown()
 initializeBattleDropdown();
 initializeGuardDropdown();
-initializeglyphsDropdown();
 fetchData();
+initializeglyphsDropdown();
 initializeTargetDropdown('start');
 initializeImportSets();
 initializeSavedSets();

--- a/js/ui/settingsui.js
+++ b/js/ui/settingsui.js
@@ -443,35 +443,77 @@ function selectTalents(talent){
     }
     
     switch (talent) {
-        case "6":
-            talents = BM_ImpHM_Track;
-            document.getElementById("currtalent").innerHTML = "BM Imp HM Tracking";
+        case "bm70":
+            talents = BM_70;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[0];
+            document.getElementById("currtalent").innerHTML = "BM 70 no Hit";
             document.getElementById("specimg").src = "images/Ability_Hunter_BeastTaming.png";
         break;
-        case "5":
-            talents = MM_ImpHM_FA_Track;
-            document.getElementById("currtalent").innerHTML = "MM ImpHM Focused Aim";
+        case "bm70hit":
+            talents = BM_70_Hit;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[1];
+            document.getElementById("currtalent").innerHTML = "BM 70 3% Hit";
+            document.getElementById("specimg").src = "images/Ability_Hunter_BeastTaming.png";
+        break;
+        case "mm70":
+            talents = MM_70;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[2];
+            document.getElementById("currtalent").innerHTML = "MM 70 no Hit";
             document.getElementById("specimg").src = "images/Ability_Marksmanship.png";
         break;
-        case "4":
-            talents = MM_ImpAS_FA_Track;
-            document.getElementById("currtalent").innerHTML = "MM ImpArcane Focused Aim";
+        case "mm70hit":
+            talents = MM_70_Hit;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[3];
+            document.getElementById("currtalent").innerHTML = "MM 70 3% Hit";
+            document.getElementById("specimg").src = "images/Ability_Marksmanship.png";
+        break;
+        case "sv70":
+            talents = SV_70;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[4];
+            document.getElementById("currtalent").innerHTML = "SV 70 no Hit";
             document.getElementById("specimg").src = "images/Ability_Hunter_Camoflauge.png";
         break;
-        case "3":
-            talents = SV_FA_Resrc_Aimed;
-            document.getElementById("currtalent").innerHTML = "SV Focused Aim Resrc Aimed Shot";
+        case "sv70hit":
+            talents = SV_70_Hit;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[5];
+            document.getElementById("currtalent").innerHTML = "SV 70 3% Hit";
             document.getElementById("specimg").src = "images/Ability_Hunter_Camoflauge.png";
         break;
-        case "2":
-            talents = BM_FA_Track;
-            document.getElementById("currtalent").innerHTML = "BM Focused Aim Tracking";
+        case "bm80":
+            talents = BM_80;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[6];
+            document.getElementById("currtalent").innerHTML = "BM 80 no Hit";
             document.getElementById("specimg").src = "images/Ability_Hunter_BeastTaming.png";
         break;
-        case "1":
-            talents = BM_FA_Track;
-            document.getElementById("currtalent").innerHTML = "BM Focused Aim Tracking";
+        case "bm80hit":
+            talents = BM_80_Hit;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[7];
+            document.getElementById("currtalent").innerHTML = "BM 80 3% Hit";
             document.getElementById("specimg").src = "images/Ability_Hunter_BeastTaming.png";
+        break;
+        case "mm80":
+            talents = MM_80;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[8];
+            document.getElementById("currtalent").innerHTML = "MM 80 no Hit";
+            document.getElementById("specimg").src = "images/Ability_Marksmanship.png";
+        break;
+        case "mm80hit":
+            talents = MM_80_Hit;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[9];
+            document.getElementById("currtalent").innerHTML = "MM 80 3% Hit";
+            document.getElementById("specimg").src = "images/Ability_Marksmanship.png";
+        break;
+        case "sv80":
+            talents = SV_80;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[10];
+            document.getElementById("currtalent").innerHTML = "SV 80 no Hit";
+            document.getElementById("specimg").src = "images/Ability_Hunter_Camoflauge.png";
+        break;
+        case "sv80hit":
+            talents = SV_80_Hit;
+            //document.getElementById("talentlink").innerHTML = "https://www.wowhead.com/wotlk/talent-calc/hunter/" + talent_presets[11];
+            document.getElementById("currtalent").innerHTML = "SV 80 3% Hit";
+            document.getElementById("specimg").src = "images/Ability_Hunter_Camoflauge.png";
         break;
         case "0":
             if (customtalentlink !== "") {
@@ -494,13 +536,16 @@ function initializeglyphsDropdown() {
 
         initial_glyph = savedglyphs;
     } else {
-        initial_glyph = '0';
+        initial_glyph = '';
     }
     
     var glyphOptions = "";
     for (let id in GLYPHS_DATA) {
-        glyphOptions += "<option value= "+id+" >" + GLYPHS_DATA[id].name + "</option>";
-      }   
+        if(GLYPHS_DATA[id].phase <= phase){
+            console.log(GLYPHS_DATA[id].phase)
+            glyphOptions += "<option value= "+id+" >" + GLYPHS_DATA[id].name + "</option>";
+        }
+    }
     
     document.getElementById("glyphSelect1").innerHTML = glyphOptions;
     document.getElementById('glyphSelect1').value = initial_glyph[0];
@@ -545,10 +590,17 @@ function spellEnableCheck(){
     let rapidcheck = document.getElementById("rapidcheck").checked;
     let lustcheck = document.getElementById("lustcheck").checked;
     let runecheck = document.getElementById("runecheck").checked;
+    let beastwithincheck = document.getElementById("beastcheck").checked;
+    let racialcheck = document.getElementById("racialcheck").checked;
+    let potioncheck = document.getElementById("potioncheck").checked;
 
     usable_CDs.rapid.enable = rapidcheck;
     usable_CDs.lust.enable = lustcheck;
     usable_CDs.rune.enable = runecheck;
+    usable_CDs.beastwithin.enable = beastwithincheck;
+    usable_CDs.berserking.enable = racialcheck;
+    usable_CDs.bloodfury.enable = racialcheck;
+    usable_CDs.potion.enable = potioncheck;
     
     storeData();
 
@@ -563,7 +615,7 @@ function spellOffsets(){
 
     usable_CDs.rapid.offset = parseInt(rapidoffset);
     usable_CDs.beastwithin.offset = parseInt(beastoffset);
-    usable_CDs.berserk.offset = parseInt(racialoffset);
+    usable_CDs.berserking.offset = parseInt(racialoffset);
     usable_CDs.bloodfury.offset = parseInt(racialoffset);
     usable_CDs.lust.offset = parseInt(lustoffset);
     usable_CDs.potion.offset = parseInt(startpotoffset);


### PR DESCRIPTION
- renamed weave time to trap weave time
- removed weaving % of fight
- updated hunter's mark debuff to work with the options for talent/glyph
- updated talent presets to have 70 and 80
- added phase 0 to prepatch
- updated all tbc items and enchants to be phase 0
- updated debuffs defaults
- added a reset for piercing shots damage on sim resets
- added phys dmg mod to all bleed dots
- fixed issue with attachment aura check for righteous wep
- added wrath enchants for feet, rings, melee wep, ranged wep, and attachments
- updated surefooted enchant to be crit and hit
- removed mongoose and executioner from options
- removed several insignificant enchants
- added note to attachments (ilvl 165)
- updated glyphs to be shown by phase
- fixed issue with glyphs sometimes giving an error
- changed pet focus regen to be 10 /s instead of 25 / 5s
- added scourgebane enchant and consecrated stones to AP calc for targets undead only
- fixed an issue that prevented saved sets from loading
- updated preferred gems for auto sorting based on lvl 80 gems to be added
- fixed an issue where glyphs werent initializing properly
- fixed an issue where setting an offset would give an error
- fixed some missing enables for buffs