### PR TITLE
add explosive trap and various bug fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,7 +782,7 @@
           <li><label class="label-2">Latency (ms)</label><input type="number" step="1" min="10" max="1000" class="number-input hover-grey fight-setting-input-3" id="latency" onchange=fightSettings() value="50"></li>
           <li><label class="label-2">Player Uptime (%)</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey fight-setting-input-3" id="playeruptime" onchange=fightSettings() value="100"> %</li>
           <li><label class="label-2">Pet Uptime (%)</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey fight-setting-input-3" id="petuptime" onchange=fightSettings() value="100"> %</li>
-          <li><label class="label-2">Trap Weave Time (s)</label><input type="number" step="0.1" min="0" max="2" class="number-input hover-grey fight-setting-input-3" id="weavetime" onchange=fightSettings() value="0.6"></li>
+          <li><label class="label-2">Trap Weave Time (s)</label><input type="number" step="0.1" min="0" max="10" class="number-input hover-grey fight-setting-input-3" id="weavetime" onchange=fightSettings() value="1.5"></li>
           <br>
           <li>
             <label class="label-2">Target</label>
@@ -1022,8 +1022,8 @@
         <option value="4">Phase 4</option>
         <option value="3">Phase 3</option>
         <option value="2">Phase 2</option>
-        <option value="1">Phase 1</option>
-        <option selected value="0">Phase 0</option>
+        <option selected value="1">Phase 1</option>
+        <option value="0">Phase 0</option>
       </select>
     </div>
     <ul class="item-selector">

--- a/js/data/auras.js
+++ b/js/data/auras.js
@@ -1062,7 +1062,7 @@ const SET_PROCS = {
         },
         effect_name: 'Stinger (T10 4pc)'
     },
-    t8_4pc_precision_shots: { // todo
+    t8_4p_precision_shots: {
         shares_cd: false,
         stat_type: 'AP',
         effect: {

--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -27,7 +27,7 @@ const SETS = {
         name: 'Cryptstalker',
         abrv: 't7',
         bonuses: {
-         2: { pet_dmg: 1.05 },
+         2: { pet_dmg: 0.05 },
          4: { speed_viper: 20 }
         }
     },

--- a/js/data/glyphs.js
+++ b/js/data/glyphs.js
@@ -45,6 +45,7 @@ const GLYPHS_DATA = {
     45733:{
         name: 'Glyph of Explosive Trap',
         abrv:'explosive_trap',
+        bonus: 1,
         icon: 'inv_glyph_majorhunter',
         phase: 1
     },
@@ -140,9 +141,7 @@ const GLYPHS_DATA = {
     },
 }
 
-var selected_glyphs = [
-    
-]
+var selected_glyphs = [45733, 45732, 42912]
 
 function selectGlyphs(glyphs_array) {
     let glyphs = {}

--- a/js/data/presetGear.js
+++ b/js/data/presetGear.js
@@ -40,6 +40,26 @@ const P1_25BIS = {
   quiver:{ id:18714 }
 }
 
+const P2_25BIS = {
+  head:{id:46143,gems:[41398,42153],enchant:59954},
+  neck:{id:45517,gems:[40002]},
+  shoulder:{id:46145,gems:[40002],enchant:59934},
+  chest:{id:45473,gems:[40014,42702,40002],enchant:60692},
+  waist:{id:45467,gems:[40002],enchant:0},
+  leg:{id:45536,gems:[40002,40002,40002],enchant:60582},
+  feet:{id:40549,gems:[],enchant:55016},
+  wrist:{id:45454,gems:[],enchant:44575},
+  hand:{id:45444,gems:[40002,40002],enchant:54999},
+  ring1:{id:46322,gems:[42153],enchant:0},
+  ring2:{id:45608,gems:[42153],enchant:0},
+  trinket1:{id:45931},
+  trinket2:{id:44253},
+  back:{id:46032,gems:[40002,40002],enchant:55002},
+  mainhand:{id:45613,gems:[40002,40002],enchant:60691,attachment:0},
+  range:{id:45570,gems:[],enchant:55135},
+  ammo:{id:41165},
+  quiver:{id:18714}
+}
 
 const DEFAULT_GEAR_SETS = [
   { description: 'P1 PreBiS 5% Hit', data: P1_PREBIS },

--- a/js/data/spell_data.js
+++ b/js/data/spell_data.js
@@ -324,10 +324,10 @@ var settings = {
     explosiveshot: true,
     blackarrow: true,
     killshot: true,
-    explosivetrap: true,
+    explosivetrap: false,
 }
 
-var weaving_enabled = true;
+var weaving_enabled = false;
 
 function updateSpellSettings() {
     settings.chimerashot = (talents.chimera_shot === 1) ? true : false;
@@ -336,6 +336,7 @@ function updateSpellSettings() {
     settings.explosiveshot = (talents.exp_shot === 1) ? true : false;
     settings.blackarrow = (talents.black_arrow === 1) ? true : false;
     settings.killshot = (level === 80) ? true : false;
+    weaving_enabled = (weavetime != 0) ? true : false;
     settings.explosivetrap = weaving_enabled;
 }
 

--- a/js/pet.js
+++ b/js/pet.js
@@ -149,7 +149,8 @@ function petStatsCalc(){
         beasttamers_crit = 2;
     };
     let group_dmg_mod = (talents.ferocious_insp > 0) ? talents.ferocious_insp : selectedbuffs.special.FerociousInsp;
-    pet.dmgmod = PetHappiness * talents.unleash_fury * racialmod * beasttamers_dmg * group_dmg_mod * pet_talents.spike_collar * talents.kindred_spirit * pet_talents.shark_attack * currentgear.special.t7_2p_pet_dmg;
+    let pet_t7_bonus = !!currentgear.special.t7_2p_pet_dmg ? currentgear.special.t7_2p_pet_dmg : 0;
+    pet.dmgmod = PetHappiness * talents.unleash_fury * racialmod * beasttamers_dmg * group_dmg_mod * pet_talents.spike_collar * talents.kindred_spirit * pet_talents.shark_attack * (1 + pet_t7_bonus);
 
     pet.str = Math.floor(Math.floor(BasePet.BaseStr + (selectedbuffs.stats.Str || 0) + (petconsumestats.Str || 0)) * selectedbuffs.special.kingsMod);
     pet.agi = Math.floor(Math.floor(BasePet.BaseAgi + (selectedbuffs.stats.Agi || 0) + (petconsumestats.Agi || 0)) * selectedbuffs.special.kingsMod);

--- a/js/player.js
+++ b/js/player.js
@@ -101,7 +101,7 @@ var rangedmgmod = 1;
 var selectedRace = 3; 
 var offhandDisabled = false;
 
-var level = 70;
+var level = 80;
 
 var useAverages = false;
 
@@ -200,7 +200,7 @@ var talents = {
    mortal_shots: 1.3, //
    GftT: 50, // 
    imp_arc_shot: 1, // 
-   aimed_shot: 1,
+   aimed_shot: 1, //
    rapid_killing: 0, //
    imp_stings: 1, //
    efficiency: 1, // ---
@@ -209,7 +209,7 @@ var talents = {
    barrage: 1, //
    combat_exp: 0, //
    ranged_weap_spec: 1, //
-   pierce_shot: 0, 
+   pierce_shot: 0, //
    trueshot_aura: 1, //
    imp_barrage: 0, //
    master_marksman: 0, //
@@ -218,7 +218,7 @@ var talents = {
    silencing_shot: 0,
    imp_steady_shot: 0, //
    mark_death: 0, //
-   chimera_shot: 0,
+   chimera_shot: 0, // 
    imp_tracking: 1.02, //
    hawk_eye: 0,// -
    savage_strikes: 0, //
@@ -241,11 +241,11 @@ var talents = {
    wyvern_sting: 0,// -
    TotH: 0, //
    master_tact: 0, //
-   nox_stings: 0,
-   no_escape: 0,
-   sniper_training: 0, // except ks crit
+   nox_stings: 0, //
+   no_escape: 0, // -
+   sniper_training: 0, //
    hunt_party: 1, // no replenishment
-   exp_shot: 0 // coded but not in sim logic
+   exp_shot: 0 //
  }
 
 /********************/
@@ -322,7 +322,7 @@ function calcBaseStats() {
     let hawkAP = (level == 70) ? 155 * (1 + talents.aspect_mast * 3) : 300 * (1 + talents.aspect_mast * 3);
     let sharedAP = Agi + (Stam * talents.hunt_vs_wild);
     BaseMAP = (GearStats.MAP + BuffStats.MAP + EnchantStats.MAP + sharedAP + Str + races[selectedRace][level].mAP + custom.MAP) * mapmod;
-    BaseRAP = (hawkAP + GearStats.RAP + BuffStats.RAP + EnchantStats.RAP + sharedAP + races[selectedRace][level].rAP + (Int * talents.careful_aim) + custom.RAP) * rapmod;
+    BaseRAP = (hawkAP + GearStats.RAP + BuffStats.RAP + EnchantStats.RAP + sharedAP + races[selectedRace][level].rAP + Math.ceil(Int * talents.careful_aim) + custom.RAP) * rapmod;
     // Crit rating and crit chance
     let critrating = GearStats.Crit + BuffStats.Crit + EnchantStats.Crit;
     MeleeCritRating = critrating + (currentgear.stats.MeleeCrit || 0) + custom.meleecrit;
@@ -376,6 +376,41 @@ function calcBaseStats() {
     BaseRangeSpeed = RANGED_WEAPONS[gear.range.id].speed / QuiverSpeed / talents.serp_swift / selectedbuffs.special.swiftRetAura;
     BaseMeleeSpeed = MELEE_WEAPONS[gear.mainhand.id].speed / selectedbuffs.special.swiftRetAura / selectedbuffs.special.melee_haste;
 
+}
+// common debug funct for checking important stats
+function debugStats(){
+
+   console.log("Gear Agi: " + GearStats.Agi)
+   console.log("Buffs Agi: " + BuffStats.Agi)
+   console.log("Enchants Agi: " + EnchantStats.Agi)
+   console.log("Race Agi: " + races[selectedRace][level].agi)
+   console.log("Mod Agi: " + agimod)
+
+   console.log("Gear Int: " + GearStats.Int)
+   console.log("Buffs Int: " + BuffStats.Int)
+   console.log("Enchants Int: " + EnchantStats.Int)
+   console.log("Race Int: " + races[selectedRace][level].int)
+   console.log("Mod Int: " + intmod)
+
+   let hawkAP = (level == 70) ? 155 * (1 + talents.aspect_mast * 3) : 300 * (1 + talents.aspect_mast * 3);
+   let sharedAP = Agi + (Stam * talents.hunt_vs_wild);
+   console.log("Hawk RAP: " + hawkAP)
+   console.log("Gear RAP: " + GearStats.RAP)
+   console.log("Buff RAP: " + BuffStats.RAP)
+   console.log("Enchant RAP: " + EnchantStats.RAP)
+   console.log("Shared RAP: " + sharedAP)
+   console.log("Race RAP: " + races[selectedRace][level].rAP)
+   console.log("Careful Aim RAP: " + Math.ceil(Int * talents.careful_aim))
+   console.log("Mod RAP: " + rapmod)
+
+   console.log("Base Crit: " + BaseCritChance)
+   console.log("Agi Crit: " + Agi / BASE_PLAYER[level].AgiToCrit)
+   console.log("Buff Crit: " + BuffStats.CritChance)
+   console.log("Killer instinct Crit: " + talents.killer_instinct)
+   console.log("Master Marksman Crit: " + talents.master_marksman * 100)
+   console.log("Rating Crit: " + RangeCritRating / BASE_PLAYER[level].CritRatingRatio)
+   console.log("Lethal Shots Crit: " + talents.lethal_shots)
+   console.log("Race Crit: " + races[selectedRace][level].critchance)
 }
 
 function initializeWeps() {

--- a/js/scripts/statCalculator.js
+++ b/js/scripts/statCalculator.js
@@ -131,53 +131,64 @@ function getMetagemBonuses(usedMeta, gemsUsed) {
 
 /** Given the gear object, calculates stats, auras and special values obtained from gems, socket bonuses and meta gem. */
 function getStatsFromGems(gear) {
-  let usedMeta
-  const gemCount = { red: 0, yellow: 0, blue: 0 }
-  const usedUniqueGems = []
+   let usedMeta
+   const gemCount = { red: 0, yellow: 0, blue: 0 }
+   const usedUniqueGems = []
 
-  const stats = Object.entries(gear).reduce((accStats, [type, gearData]) => {
-    if (!gearData.gems) return accStats
+   const stats = Object.entries(gear).reduce((accStats, [type, gearData]) => {
+      if (!gearData.gems) return accStats
 
-    const gearPiece = GEAR_MAP[type][gearData.id]
-    const numSockets = gearPiece.sockets?.length || 0
-    const numGems = gearData.gems.length
-    let isBonusFulfilled = numSockets === numGems
-    if (numGems > numSockets)
-      throw new Error(`Tried to put ${numGems} gems in "${gearPiece.name}", which only has ${numSockets} sockets.`)
-
-    gearData.gems.forEach((gemId, i) => {
-      if (!gemId) {
-        isBonusFulfilled = false
-        return;
+      const gearPiece = GEAR_MAP[type][gearData.id]
+      if (type == 'waist' || type == 'wrist' || type == 'hand') {
+         if (!!gearPiece.sockets) {
+            if (!gearPiece.sockets.includes('Meta')) {
+               gearPiece.sockets.push('Meta');
+            }
+         }
+         else {
+            gearPiece.sockets = ['Meta'];
+         }
       }
+    
+      const numSockets = gearPiece.sockets?.length || 0
+      const numGems = gearData.gems.length
+      let isBonusFulfilled = numSockets === numGems
+      if (numGems > numSockets)
+         throw new Error(`Tried to put ${numGems} gems in "${gearPiece.name}", which only has ${numSockets} sockets.`)
 
-      if (!GEMS[gemId]) throw new Error(`Detected invalid gem with id ${gemId}`)
-      const gem = GEMS[gemId]
-      const socket = gearPiece.sockets[i]
+      gearData.gems.forEach((gemId, i) => {
+         if (!gemId) {
+            isBonusFulfilled = false
+            return;
+         }
 
-      if (gem.unique) {
-          if (usedUniqueGems.includes(gemId)) throw new Error(`Tried to used unique gem "${gem.name}" more than once.`)
-          else usedUniqueGems.push(gemId)
-      }
+         if (!GEMS[gemId]) throw new Error(`Detected invalid gem with id ${gemId}`)
+         const gem = GEMS[gemId]
+         const socket = gearPiece.sockets[i]
 
-      if (gem.meta === 'Y') {
-        if (socket !== 'Meta') throw new Error(`Tried to fit non-meta gem in meta socket`)
-        usedMeta = gemId
-      } else {
-        sumStats(gem.stats, accStats)
-        gem.colors.forEach(color => ++gemCount[color])
-        if (!gem.colors.includes(socket.toLowerCase())) isBonusFulfilled = false
-      }
-    })
+         if (gem.unique) {
+            if (usedUniqueGems.includes(gemId)) throw new Error(`Tried to used unique gem "${gem.name}" more than once.`)
+            else usedUniqueGems.push(gemId)
+         }
 
-    if (isBonusFulfilled && gearPiece.socketBonus) sumStats(gearPiece.socketBonus, accStats)
-    return accStats
-  }, {})
-  gemsTotalsEquipped = gemCount
-  const result = getMetagemBonuses(usedMeta, gemCount)
-  sumStats(stats, result.stats)
+         if (gem.meta === 'Y') {
+            if (socket !== 'Meta') throw new Error(`Tried to fit non-meta gem in meta socket`)
+            usedMeta = gemId
+         } else {
+            sumStats(gem.stats, accStats)
+            gem.colors.forEach(color => ++gemCount[color])
+            if (!gem.colors.includes(socket.toLowerCase())) isBonusFulfilled = false
+         }
+      })
 
-  return result
+      if (isBonusFulfilled && gearPiece.socketBonus) sumStats(gearPiece.socketBonus, accStats)
+      return accStats
+   }, {})
+   gemsTotalsEquipped = gemCount
+   const result = getMetagemBonuses(usedMeta, gemCount)
+   sumStats(stats, result.stats)
+
+   return result
 }
 
 /** Given the gear object, calculates stats, auras and special values obtained from enchants */

--- a/js/sim/aurahandling.js
+++ b/js/sim/aurahandling.js
@@ -631,9 +631,24 @@ function dotHandler(dotname, source, apply, type, crit_dmg) {
             }
             spellresult[dotname].count++;
         }
+        else if (dotname === 'explosivetrap') { // tick RAP damage updated per tick
+            let crittable = (!!glyphs.explosive_trap && dotname === 'explosivetrap') ? true : false;
+
+            auras.explosivetrap.damage = explosiveTrapCalc(combatRAP, true);
+            result = rollDamageOverTime(crittable, dotname);
+            dmg = auras[dotname].damage * magdmgmod;
+            
+            if (result === RESULT.PARTIAL) {
+                dmg *= 0.65; // average reduction of 35% on partial resists
+            }
+            else if (result === RESULT.CRIT) {
+                dmg *= MeleeCritDamage;
+            }
+            procDoT();
+        }
         else if (dottype !== 'physical') {
             updateDmgMod(dotname);
-            let crittable = (!!glyphs.explosive_trap && dotname === 'explosivetrap') ? true : false; // todo future crits trap and serpent crit conditions
+            let crittable = (!!currentgear.special.t9_2p_serpent_crits && dotname === 'serpentsting') ? true : false; 
             let ticks = (auras[dotname].effect.duration + (glyphs.serpent_sting || 0)) / auras[dotname].effect.tick_rate;
             result = rollDamageOverTime(crittable, dotname);
             dmg = auras[dotname].damage / ticks * magdmgmod;
@@ -644,12 +659,12 @@ function dotHandler(dotname, source, apply, type, crit_dmg) {
                 dmg *= RangeCritDamage;
             }
 
-            if (dotname === 'blackarrow' || dotname === 'explosivetrap' || dotname === 'immolatetrap') {
+            if (dotname === 'blackarrow' || dotname === 'immolatetrap') {
                 procDoT();
             }
             //console.log(dmg + " " +result)
         } 
-
+        // removes 6% damage increase for black arrow itself, since it doesn't buff itself
         if (dotname === 'blackarrow') {
             dmg *= targetdmgmod / 1.06;
         }
@@ -661,8 +676,8 @@ function dotHandler(dotname, source, apply, type, crit_dmg) {
         spellresult[dotname].dmg += done;
 
         if(combatlogRun) {
-            let critstring = (result === RESULT.CRIT) ? " (Crit)" : "";
-            combatlogarray[combatlogindex] = next_dot_time.toFixed(3) + " - Target takes " + done + " damage from " + auras[dotname].effect_name + critstring;
+            let resultstring = " (" + RESULTARRAY[result] + ")";
+            combatlogarray[combatlogindex] = next_dot_time.toFixed(3) + " - Target takes " + done + " damage from " + auras[dotname].effect_name + resultstring;
             combatlogindex++;
         }
         auras[dotname].ticks -= 1;

--- a/js/sim/expected_dmg.js
+++ b/js/sim/expected_dmg.js
@@ -140,6 +140,14 @@ function exp_dmgMod_Magic(critbonus) {
 
    return range_wep.basedmgmod*magdmgmod*combatdmgmod*rangehit*((RangeCritDamage-1)*rangecrit + 1);
 }
+function exp_dmgMod_Magic_Traps(critbonus) {
+
+   let rangemiss = Math.max(RangeMissChance,0)*0.01;
+   let rangehit = 1 - rangemiss;
+   let rangecrit = (_combatCritChance + critbonus)*0.01;
+
+   return range_wep.basedmgmod*magdmgmod*combatdmgmod*rangehit*((MeleeCritDamage-1)*rangecrit + 1);
+}
 function exp_dmgMod_SpecialMagic(critbonus) {
 
    let rangemiss = Math.max(RangeMissChance,0)*0.01;
@@ -256,7 +264,7 @@ function exp_dmg_ChimeraShot(range_wep, combatRAP) {
 function exp_dmg_ExplosiveShot(combatRAP) {
 
    let sniper_training = (auras.sniper_training?.timer > 0) ? talents.sniper_training * 2 : 0;
-   let dmg = (useAverages) ? (SPELLS.explosiveshot.mindmg + SPELLS.explosiveshot.maxdmg) * avgConst : rng(SPELLS.explosiveshot.mindmg,SPELLS.explosiveshot.maxdmg);
+   let dmg = (useAverages) ? (SPELLS.explosiveshot.ranks.mindmg + SPELLS.explosiveshot.ranks.maxdmg) * avgConst : rng(SPELLS.explosiveshot.mindmg,SPELLS.explosiveshot.maxdmg);
    let specials_mod = 1 + talents.t_n_t + sniper_training;
    let shotDmg = (combatRAP * 0.14 + dmg) * specials_mod;
    return shotDmg * exp_dmgMod_Magic(talents.surv_instincts) * 3;
@@ -273,15 +281,14 @@ function exp_dmg_SerpentSting(combatRAP) {
    // Explosive Trap
 function exp_dmg_ExplosiveTrap(combatRAP) {
 
-   let dot = dotcheck;
    let dmg = 0;
    let dotDmg = 0;
    let trapDmg = 0;
-   
-   dotDmg = SPELLS.explosivetrap.tickdmg * 10 + combatRAP;
-   dmg = (SPELLS.explosivetrap.mindmg + SPELLS.explosivetrap.maxdmg) * avgConst;
+   let specialmod = (1 + talents.t_n_t + talents.trap_mastery); 
+   dotDmg = (SPELLS.explosivetrap.ranks.dot_dmg * 10 + combatRAP) * specialmod;
+   dmg = (SPELLS.explosivetrap.ranks.mindmg + SPELLS.explosivetrap.ranks.maxdmg) * avgConst;
    trapDmg = (combatRAP * 0.10 + dmg) + dotDmg;
-   return trapDmg * exp_dmgMod_Magic(0);
+   return trapDmg * exp_dmgMod_Magic_Traps(0);
 }
    // Immolation Trap
 function exp_dmg_ImmolateTrap(combatRAP) {

--- a/js/sim/spells.js
+++ b/js/sim/spells.js
@@ -15,7 +15,7 @@ function initializeSpells(){
     if(!!USED_SPELLS.chimerashot) USED_SPELLS.chimerashot.cd = 0;
     if(!!USED_SPELLS.explosiveshot) USED_SPELLS.explosiveshot.cd = 0;
     if(!!USED_SPELLS.serpentsting) USED_SPELLS.serpentsting.cd = 0;
-    if(!!USED_SPELLS.explosivetrap) USED_SPELLS.explosivetrap.cd = 0;
+    if(!!USED_SPELLS.explosivetrap) USED_SPELLS.explosivetrap.cd = 4;
     if(!!USED_SPELLS.immolatetrap) USED_SPELLS.immolatetrap.cd = 0;
     if(!!USED_SPELLS.frosttrap) USED_SPELLS.frosttrap.cd = 0;
     if(!!USED_SPELLS.snaketrap) USED_SPELLS.snaketrap.cd = 0;
@@ -274,7 +274,7 @@ function explosiveShotCalc(combatRAP) {
     // Serpent Sting
 function serpentStingCalc(combatRAP) {
 
-    let serpent_mod = (!!currentgear.special.t8_serpent_dmg_bonus) ? currentgear.special.t8_serpent_dmg_bonus : 0;
+    let serpent_mod = (!!currentgear.special.t8_2p_serpent_dmg) ? currentgear.special.t8_2p_serpent_dmg / 100 : 0;
     let specials_mod = (1 + talents.imp_stings + serpent_mod);
     let ticks = (auras.serpentsting.effect.duration + (glyphs.serpent_sting || 0)) / auras.serpentsting.effect.tick_rate;
     let shotDmg = (combatRAP * 0.04 + SPELLS.serpentsting.ranks.rankdmg) * ticks * dmgmod * specials_mod * combatdmgmod;
@@ -288,11 +288,11 @@ function explosiveTrapCalc(combatRAP, dotcheck) {
     let trapDmg = 0;
     let specialmod = (1 + talents.t_n_t + talents.trap_mastery);
     if(dotcheck) {
-        dotDmg = (SPELLS.explosivetrap.ranks.tickdmg * 10 + combatRAP) * combatdmgmod * specialmod;
+        dotDmg = (SPELLS.explosivetrap.ranks.dot_dmg + combatRAP * 0.10 ) * combatdmgmod * specialmod;
         return dotDmg;
     } else {
         dmg = (useAverages) ? (SPELLS.explosivetrap.ranks.mindmg + SPELLS.explosivetrap.ranks.maxdmg) * avgConst : rng(SPELLS.explosivetrap.ranks.mindmg,SPELLS.explosivetrap.ranks.maxdmg);
-        trapDmg = (combatRAP * 0.10 + dmg) * specialmod * combatdmgmod * magdmgmod;
+        trapDmg = (combatRAP * 0.10 + dmg) * (specialmod - talents.trap_mastery) * combatdmgmod * magdmgmod;
         return trapDmg;
     }
 }

--- a/js/ui/datastorage.js
+++ b/js/ui/datastorage.js
@@ -184,13 +184,21 @@ function fetchData(){
     document.getElementById("level").value = target.level;
 
     document.getElementById("replenish").checked = replenishment;
+    
+    let flask = !!playerconsumes.flask ? playerconsumes.flask : 0;
+    document.getElementById("flask").value = (localStorage.getItem("flask") != null) ?  localStorage.getItem('flask') : flask;
 
-    document.getElementById("flask").value = (localStorage.getItem("flask") != null) ?  localStorage.getItem('flask') : document.getElementById("flask").value;
-    document.getElementById("battle").value = (localStorage.getItem("battle") != null) ?  localStorage.getItem('battle') : document.getElementById("battle").value;
-    document.getElementById("guardian").value = (localStorage.getItem("guardian") != null) ?  localStorage.getItem('guardian') : document.getElementById("guardian").value;
-    document.getElementById("food").value = (localStorage.getItem("food") != null) ?  localStorage.getItem('food') : document.getElementById("food").value;
-    //console.log(localStorage.getItem("food"))
-    document.getElementById("petfood").value = (localStorage.getItem("petfood") != null) ?  localStorage.getItem('petfood') : document.getElementById("petfood").value;
+    let battle = !!playerconsumes.battle ? playerconsumes.battle : 0;
+    document.getElementById("battle").value = (localStorage.getItem("battle") != null) ?  localStorage.getItem('battle') : battle;
+
+    let guardian = !!playerconsumes.guardian ? playerconsumes.guardian : 0;
+    document.getElementById("guardian").value = (localStorage.getItem("guardian") != null) ?  localStorage.getItem('guardian') : guardian;
+
+    let food = !!playerconsumes.food ? playerconsumes.food : 0;
+    document.getElementById("food").value = (localStorage.getItem("food") != null) ?  localStorage.getItem('food') : food;
+
+    let pet_food = !!petconsumes.pet_food ? petconsumes.pet_food : 0;
+    document.getElementById("petfood").value = (localStorage.getItem("petfood") != null) ?  localStorage.getItem('petfood') : pet_food;
     
     // buffs visual initialization
     document.getElementById("apbuff").checked = (buffslist[0].id == 2048) ? true : false;
@@ -214,7 +222,7 @@ function fetchData(){
     document.getElementById("fortmod").selected = (buffslist[13].talented) ? true : false;
 
     let errorchk_talent = (talentindex == "bm70" || talentindex == "bm70hit" || talentindex == "bm80" || talentindex == "bm80hit" || talentindex == "mm70" || talentindex == "mm70hit" || talentindex == "mm80" || talentindex == "mm80hit" || talentindex == "sv70" || talentindex == "sv70hit" || talentindex == "sv80" || talentindex == "sv80hit" || talentindex == "0")
-    talentindex = (errorchk_talent) ? talentindex : "mm70";
+    talentindex = (errorchk_talent) ? talentindex : "mm80";
     document.getElementById("talentselect").value = talentindex;
     document.getElementById("customtalent").value = whtalentlink;
     

--- a/js/ui/gearui.js
+++ b/js/ui/gearui.js
@@ -437,6 +437,10 @@ function gemSelectorDisplay(slotarray){
     Object.filter = (obj, predicate) => Object.fromEntries(Object.entries(obj).filter(predicate));
 
     let skt = (slotarray[gear[activeslot].id].hasOwnProperty('sockets')) ? slotarray[gear[activeslot].id].sockets : [];
+    if (activeslot == 'waist' || activeslot == 'wrist' || activeslot == 'hand') {
+        if (!skt.includes('Meta')) skt.push('Meta');
+    }
+
     if (skt.length > 0){
         gem1 = gear[activeslot].gems[0] || 0;
         gem2 = gear[activeslot].gems[1] || 0;
@@ -446,7 +450,7 @@ function gemSelectorDisplay(slotarray){
         let NO_META = Object.filter(GEMS, ([key, obj]) => obj.meta !== 'Y');
         if(skt.length < 1){
         } else {
-            if (skt[0] === 'Meta') {
+            if (skt[0] === 'Meta' && activeslot === 'head') {
                 metaselectOptions = generateGearOptionsList(META,'gem1');
             } else {
                 gemselectOptions = generateGearOptionsList(NO_META,'gem1');
@@ -454,7 +458,7 @@ function gemSelectorDisplay(slotarray){
         }
         if(skt.length < 2){
         } else {
-            if (skt[1] === 'Meta') {
+            if (skt[1] === 'Meta' && activeslot === 'head') {
                 metaselectOptions = generateGearOptionsList(META,'gem2');
             } else {
                 gemselectOptions = generateGearOptionsList(NO_META,'gem2');
@@ -462,7 +466,7 @@ function gemSelectorDisplay(slotarray){
         }
         if(skt.length < 3){
         } else {
-            if (skt[2] === 'Meta') {
+            if (skt[2] === 'Meta' && activeslot === 'head') {
                 metaselectOptions = generateGearOptionsList(META,'gem3');
             } else {
                 gemselectOptions = generateGearOptionsList(NO_META,'gem3');
@@ -687,8 +691,8 @@ function getStatsCapData(){
 function estimateDps(item, weights) {
     let dps = 0;
     // check for meta gems
-    if (item.name == 'Relentless Earthstorm Diamond') {
-        dps += weights.relentless + weights.Agi * 12;
+    if (item.name == 'Relentless Earthsiege Diamond (+21 Agi, +3% Crit Dmg)') {
+        dps += weights.relentless + weights.Agi * 21;
         return dps;
     } 
     // check for weightstone/sharp stone for weps
@@ -741,7 +745,7 @@ function estimateDps(item, weights) {
         var allRed = 0;
         if(activeslot == 'head' && item.sockets.includes('Meta')){
             allRed = ((item.sockets.length - 1) > 0) ? (item.sockets.length - 1) * estimateDps(GEMS[preferredGems.Red], weights) : 0;
-            allRed += weights.relentless + weights.Agi * 12;
+            allRed += weights.relentless + weights.Agi * 21;
         } else {
             allRed = item.sockets.length * estimateDps(GEMS[preferredGems.Red], weights);
         }
@@ -955,6 +959,10 @@ function displayCurrentGearTabs(){
     let gearobj = GEAR_MAP[activeslot];
     let enchobj = ENCHANT_MAP[activeslot];
     let skt = (gearobj[currgear.id].hasOwnProperty('sockets')) ? gearobj[currgear.id].sockets : [];
+    if (activeslot == 'waist' || activeslot == 'wrist' || activeslot == 'hand') {
+        if (!skt.includes('Meta')) skt.push('Meta');
+    }
+
     let defaultench = "https://wow.zamimg.com/images/wow/icons/large/inv_misc_note_01.jpg"
     let defaultattach = "https://wow.zamimg.com/images/wow/icons/large/inv_stone_weightstone_07.jpg"
 
@@ -1317,6 +1325,7 @@ function gearSlotsDisplay(){
     let wristgem2 = 0;
 
     let wristskt = (WRISTS[gear.wrist.id].hasOwnProperty('sockets')) ? WRISTS[gear.wrist.id].sockets : [];
+    if (!wristskt.includes('Meta')) wristskt.push('Meta');
     if (wristskt.length >= 1) { 
         document.getElementsByClassName("itemsocket")[11].style.display = "block";
         document.getElementById("wristskt1").src = "images/" + wristskt[0] + "_empty.jfif";
@@ -1561,6 +1570,7 @@ function gearSlotsDisplay(){
     let handgem3 = 0;
 
     let handskt = (HANDS[gear.hand.id].hasOwnProperty('sockets')) ? HANDS[gear.hand.id].sockets : [];
+    if (!handskt.includes('Meta')) handskt.push('Meta');
     if (handskt.length >= 1) { 
         document.getElementsByClassName("itemsocket")[21].style.display = "block";
         document.getElementById("handskt1").src = "images/" + handskt[0] + "_empty.jfif";
@@ -1621,6 +1631,8 @@ function gearSlotsDisplay(){
     let waistgem3 = 0;
 
     let waistskt = (WAISTS[gear.waist.id].hasOwnProperty('sockets')) ? WAISTS[gear.waist.id].sockets : [];
+    if (!waistskt.includes('Meta')) waistskt.push('Meta');
+
     if (waistskt.length >= 1) { 
         document.getElementsByClassName("itemsocket")[24].style.display = "block";
         document.getElementById("waistskt1").src = "images/" + waistskt[0] + "_empty.jfif";

--- a/js/ui/statsgraphs.js
+++ b/js/ui/statsgraphs.js
@@ -10,6 +10,7 @@ var spellresult = {
 	chimerashot: { Hit: 0, Miss: 0, Crit: 0, Partial: 0, count: 0, dmg: 0 },
 	arcaneshot: { Hit: 0, Miss: 0, Crit: 0, Partial: 0, count: 0, dmg: 0 },
 	explosiveshot: { Hit: 0, Miss: 0, Crit: 0, Partial: 0, count: 0, dmg: 0 },
+	explosivetrap: { Hit: 0, Miss: 0, Crit: 0, Partial: 0, count: 0, dmg: 0 },
 	killshot: { Hit: 0, Miss: 0, Crit: 0, count: 0, dmg: 0 },
 	serpentsting: { Hit: 0, Miss: 0, Crit: 0, count: 0, dmg: 0 },
 	blackarrow: { Hit: 0, Miss: 0, count: 0, dmg: 0 },
@@ -444,6 +445,7 @@ function damageResults(){
 		chimerashot: {},
 		arcaneshot: {},
 		explosiveshot: {},
+		explosivetrap: {},
 		killshot: {},
 		serpentsting: {},
 		blackarrow: {},
@@ -561,7 +563,7 @@ function resultCountInitialize() {
 		spellresult[spellname].count = 0;
 		spellresult[spellname].dmg = 0;
 		
-		if (spellname === 'pet_special' || spellname === 'wild_quiver' || spellname === 'arcaneshot' || spellname === 'chimera_serpent' || spellname === 'explosiveshot' || spellname === 'chimerashot') {
+		if (spellname === 'pet_special' || spellname === 'wild_quiver' || spellname === 'arcaneshot' || spellname === 'chimera_serpent' || spellname === 'explosiveshot' || spellname === 'chimerashot' || spellname === 'explosivetrap') {
 			spellresult[spellname].Partial = 0;
 		}
 		if (spellname === 'pet_focus_dump' || spellname === 'petattack' || spellname === 'raptorstrike' || spellname === 'melee') {


### PR DESCRIPTION
- changed default phase to 1
- changed weave time to disable traps if set to 0
- added t8 4pc proc to possible auras and added the trigger
- fixed issue with t7 2pc being incorrectly applied
- changed default glyphs
- investigated p2 bis based on weights
- changed level default to 80
- changed careful aim RAP to round up
- added a debug funct for important stats for easier troubleshooting stats
- added bonus sockets to wrist, hand and waist, currently not restricted to only BS for wrist and hand
- added explosive trap to used spells if weave time > 0
- adjusted result string for dots to show hit type for all ticks
- added serpent sting and explosive trap crittable checks
- fixed issue with explosive shot doing very low damage when simming EP
- fixed explosive trap using wrong name for dot ticks
- fixed issue where scourgebane wasnt adding the target AP
- added partial resists to serpent sting and black arrow
- removed efficiency from traps
- changed crit damage for traps to be melee crit dmg not range crit dmg
- added error checks for invalid steps in sim loop
- added delay to next auto if player traps
- traps currently treated like a cast with no spells during movement
- changed how weave time was handled
- added spell haste to trap gcd
- fixed an issue where the initial hit from traps was benefitting from trap mastery
- Fixed an issue with how traps were calculating damage
- changed default talents from 70 to 80 MM
- added some checks for default food/flask/etc.
- changed meta gem list to only appear if socket is meta and slot is head
- adjusted relentless dps weight to be 21 agi instead of 12 like tbc
- added explosive trap to spell result tracking